### PR TITLE
CRUD on programs... yay!

### DIFF
--- a/binfrastructure/django/world/models.py
+++ b/binfrastructure/django/world/models.py
@@ -1,5 +1,8 @@
 from django.db import models
 import json
+import logging
+
+logger = logging.getLogger('dev')
 
 
 class Pose(models.Model):
@@ -57,15 +60,17 @@ BIF Actions are modeled as a (name, params) pair, where the "name" is one of
 the defined in the API, identifying the function to call, and the "params" is a
 string of space separated values to be interpreted as the function paramter(s).
 
-Each BIF Action is expected to be able to build its arguments form the "params"
-string. As an example, consider a "go_to_pose" action receiving a params string
-like "3.0 -2.2 1.5". It should correspond to a call to
+Each BIF Action is expected to be able to build its arguments from the "params"
+string (which is a JSON stringified). As an example, consider a "go_to_pose"
+action receiving a params string like "3.0 -2.2 1.5". It should correspond to a
+call to
 
    go_to_pose(Pose(x=3.0, y=-2.2, angle=1.5))
 
 The to_dict() method of a BIFAction produces a dict instance with keys "name"
-and "arguments". The "name" is the API function to invoke; the "arguments" is a
-python object, ready to be passed to that function.
+and "params". The "name" is the API function to invoke; the "params" is a
+python object (corresponding to the 'params' JSON object stringified in the
+model instance), ready to be passed to that function.
 
 It is to be noted that the "params" string is limited. This is so to simplify
 implementation. The maximum length is exposed as MAX_LENGTH_PARAMS_STRING.
@@ -150,12 +155,12 @@ class BIFAction(models.Model):
 
         Raises ValueError if data is not good.
         """
-        if not ('name' in dict_action and 'arguments' in dict_action):
-            raise ValueError('The dict() needs "name" and "arguments"')
+        if not ('name' in dict_action and 'params' in dict_action):
+            raise ValueError('The dict() needs "name" and "params"')
         if dict_action['name'] not in [c[0] for c in API_call_choices]:
             raise ValueError('bad bif_action name.')
         return _class(name=dict_action['name'],
-                      params=json.dumps(dict_action['arguments']))
+                      params=json.dumps(dict_action['params']))
 
     def to_dict(self):
         """Produce a dict() representation of this instance.
@@ -166,14 +171,15 @@ class BIFAction(models.Model):
         if self.name not in [c[0] for c in API_call_choices]:
             raise ValueError("bad API call name.")
 
-        arguments = json.loads(self.params)
+        params = json.loads(self.params)
         if self.name == "go_to_pose":
-            arguments = Pose(**arguments)
+            params = Pose(**params)
 
-        return {
+        action_dict = {
             'name': self.name,
-            'arguments': arguments
+            'params': params
         }
+        return action_dict
 
 
 class BIFProgram(models.Model):
@@ -187,3 +193,22 @@ class BIFProgram(models.Model):
         """Return a QuerySet with the BIFAction instances which compose this
         program, ordered as they should be executed."""
         return self.instructions.order_by('instruction_number')
+
+    def replace_instruction_sequence(self, instruction_sequence):
+        """Allow to replace the instruction sequence of this program.
+
+        Each element in the "instruction_sequence" sequence is a BIFAction
+        instance, which will be commited to the database if it has not yet been
+        save()'d.
+
+        It is to be noted that the BIFActions are not copied, but assigned to
+        this program. If these BIFActions correspond to a different program,
+        said program would end up empty.
+        """
+        # Delete current instructions.
+        for instruction in self.instruction_sequence:
+            instruction.delete()
+        # Add the new instructions.
+        for instruction in instruction_sequence:
+            instruction.program = self
+            instruction.save()

--- a/binfrastructure/django/world/resturls.py
+++ b/binfrastructure/django/world/resturls.py
@@ -1,6 +1,13 @@
-from rest_framework import generics, serializers
+import json
+import logging
+from rest_framework import status, generics, serializers
+from rest_framework.decorators import parser_classes, api_view
+from rest_framework.parsers import JSONParser
+from rest_framework.response import Response
 from django.conf.urls.defaults import patterns, url
-from models import Pose, BinLocation, BIFProgram, BIFAction
+from world.models import Pose, BinLocation, BIFProgram, BIFAction
+
+logger = logging.getLogger('dev')
 
 
 class ExplicitPoseSerializer(serializers.ModelSerializer):
@@ -34,6 +41,50 @@ class ProgramSerializer(serializers.ModelSerializer):
         depth = 1
 
 
+@api_view(['GET', 'PUT', 'DELETE'])
+@parser_classes([JSONParser])
+def single_program(request, pk, format=None):
+    """Operate on a single program.
+
+    TODO: implement as a class based view; the REST framework can reduce this
+    code to three small methods.
+    """
+
+    program = BIFProgram.objects.get(pk=pk)
+    if request.method == 'GET':
+        # Get the program from the system.
+        serializer = ProgramSerializer(program)
+        return Response(serializer.data)
+
+    elif request.method == 'PUT':
+        # Replace the program with the edited version (JSON encoded).
+        try:
+            program_data = request.DATA
+            # new_program_data = json.loads(data)
+            new_name = program_data['name']
+            instructions_data = program_data['instructions']
+            new_instructions = []
+            for action_dict in instructions_data:
+                new_instructions.append(BIFAction.from_dict(action_dict))
+
+        except (ValueError, KeyError) as e:
+            # KeyError: POSTed data does not have a "program" data.
+            # ValueError: POSTed program had invalid JSON format.
+            # ValueError: interpreted program is not a BIF program.
+            logger.debug('Exception serializing a program: %s' % e)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+        program.name = new_name
+        program.replace_instruction_sequence(new_instructions)
+        program.save()
+        serializer = ProgramSerializer(program)
+        return Response(serializer.data, status.HTTP_200_OK)
+
+    elif request.method == 'DELETE':
+        # Deleting a program deletes all of its instructions.
+        program.delete()
+        return Response(status.HTTP_200_OK)
+
+
 urlpatterns = patterns('',
     url(r'^binlocations$', generics.ListAPIView.as_view(
         model=BinLocation,
@@ -45,4 +96,5 @@ urlpatterns = patterns('',
     url(r'^programs$', generics.ListAPIView.as_view(
         model=BIFProgram,
         serializer_class=ProgramSerializer)),
+    url(r'^programs/(?P<pk>[^/]+)$', single_program),
 )


### PR DESCRIPTION
Programs are now exposed through the REST API at `/world/programs/${program_id}`, which allows GET, PUT and DELETE.

_I know we're not going to need this right now, but I couldn't help it_
